### PR TITLE
Enriched interfaces to reduce need to use Reflection in some scenarios

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
   vmImage: ubuntu-latest
 
 variables:
-  dotNetVersion: '6.0.x'
+  dotNetVersion: '8.0.x'
 
 stages:
   - stage: Compile_Test

--- a/src/OperationResult.Tests/GenericConstraintsTests.cs
+++ b/src/OperationResult.Tests/GenericConstraintsTests.cs
@@ -1,0 +1,67 @@
+﻿namespace OperationResult.Tests;
+public class GenericConstraintsTests
+{
+    [Fact]
+    public async Task CallToStaticErrorMethodFromGenericTypeDefinitionReturnsGenericResult()
+    {
+        //Arrange
+        RequestWithResultValue request = new("data");
+        var behavior = new ExceptionPipelineBehavior<RequestWithResultValue, Result<SimpleResponse>>();
+
+        //Act
+        var result = await behavior.Handle(request, Next);
+
+        //Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Exception.Should().BeOfType<NotImplementedException>();
+
+        static Task<Result<SimpleResponse>> Next(RequestWithResultValue request)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task CallToStaticErrorMethodFromGenericTypeDefinitionReturnsNonGenericResult()
+    {
+        //Arrange
+        RequestWithNoResultValue request = new("data");
+        var behavior = new ExceptionPipelineBehavior<RequestWithNoResultValue, Result>();
+
+        //Act
+        var result = await behavior.Handle(request, Next);
+
+        //Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Exception.Should().BeOfType<NotImplementedException>();
+
+        static Task<Result> Next(RequestWithNoResultValue request)
+            => throw new NotImplementedException();
+    }
+}
+
+public record RequestWithNoResultValue(string Value) : IRequest<Result>;
+public record RequestWithResultValue(string Value) : IRequest<Result<SimpleResponse>>;
+public record SimpleResponse(string Value);
+
+public interface IRequest<TResponse>;
+
+public interface IPipelineBehavior<TRequest, TResponse>
+{
+    Task<TResponse> Handle(TRequest request, Func<TRequest, Task<TResponse>> next);
+}
+
+public sealed class ExceptionPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+    where TResponse : IResult<TResponse>
+{
+    public async Task<TResponse> Handle(TRequest request, Func<TRequest, Task<TResponse>> next)
+    {
+        try
+        {
+            return await next(request);
+        }
+        catch (Exception ex)
+        {
+            return TResponse.Error(ex);
+        }
+    }
+}

--- a/src/OperationResult.Tests/OperationResult.Tests.csproj
+++ b/src/OperationResult.Tests/OperationResult.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   

--- a/src/OperationResult.Tests/OperationResult.Tests.csproj
+++ b/src/OperationResult.Tests/OperationResult.Tests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latestMajor</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
+    <NoWarn>$(NoWarn);CA2252</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OperationResult/IResult.cs
+++ b/src/OperationResult/IResult.cs
@@ -1,7 +1,12 @@
 ﻿namespace OperationResult;
 
-public interface IResult
+public interface IResult<TSelf>
+    where TSelf : IResult<TSelf>?
 {
     Exception? Exception { get; }
     bool IsSuccess { get; }
+
+    static abstract TSelf Success();
+
+    static abstract TSelf Error(Exception error);
 }

--- a/src/OperationResult/IResultValue.cs
+++ b/src/OperationResult/IResultValue.cs
@@ -1,0 +1,9 @@
+﻿namespace OperationResult;
+
+public interface IResultValue<TIn, TSelf> : IResult<TSelf>
+    where TSelf : IResultValue<TIn, TSelf>
+{
+    public TIn? Value { get; }
+
+    static abstract TSelf Success(TIn value);
+}

--- a/src/OperationResult/OperationResult.csproj
+++ b/src/OperationResult/OperationResult.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latestMajor</LangVersion>
     <Authors>Victor Divino</Authors>
     <Product>OperationResult</Product>
     <PackageId>Divino.OperationResult</PackageId>
@@ -12,8 +13,12 @@
     <PackageProjectUrl>https://github.com/victorDivino/operationResult</PackageProjectUrl>
     <RepositoryUrl>https://github.com/victorDivino/operationResult</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.1.0</Version>
+    <NoWarn>$(NoWarn);CA2252</NoWarn>
+    <Version>4.0.0</Version>
     <releaseNotes>
+      ## Version 4.0.0 ##
+      - Dropped support from netstandard2.0;net5.0 in favor to use new C# features that require new TFM version
+      - Enriched interfaces to reduce need to use Reflection in some scenarios.
       ## Version 3.1.0 ##
       - Added interface to make it easy to identify the Result, even when it is generic version
       ## Version 3.0.0 ##

--- a/src/OperationResult/Result.cs
+++ b/src/OperationResult/Result.cs
@@ -1,11 +1,11 @@
-﻿namespace OperationResult;
+﻿using System.Diagnostics.CodeAnalysis;
 
-public struct Result : IResult
+namespace OperationResult;
+
+public struct Result : IResult<Result>
 {
     public Exception? Exception { get; }
-#if NET5_0_OR_GREATER
-    [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, nameof(Exception))]
-#endif
+    [MemberNotNullWhen(false, nameof(Exception))]
     public bool IsSuccess { get; }
 
     public Result(bool success)
@@ -24,7 +24,10 @@ public struct Result : IResult
         where TException : Exception
         => Exception is TException;
 
-    public static Result Success()
+    public static IResult<Result> Success()
+        => new Result(true);
+
+    static Result IResult<Result>.Success()
         => new(true);
 
     public static Result Error(Exception exception)


### PR DESCRIPTION
This PRs generates breaking changes by dropping support to netstandard2.0 and net5.0.

The capability added in this PR needs a newer version of .NET, at least .NET 6.0

The `IResult` interface was added in previous versions to use it in some generic constraints.

But there are 2 kinds of results:

- Generic, with Value, IsSuccess and Exception properties
- Non-generic, with IsSuccess and Exception properties

In some scenarios using `IResult` interface as generic constraints would not be able to produce the proper Result without using Reflection.

The following class can receive the `Result` or `Result<string>` since both inherit from `IResult`.

```csharp
public sealed class ExceptionPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
    where TRequest : IRequest<TResponse>
    where TResponse : IResult
{
    public async Task<TResponse> Handle(TRequest request, Func<TRequest, Task<TResponse>> next)
    {
        try
        {
            return await next(request);
        }
        catch (Exception ex)
        {
            // How to produce the proper Result, Generic or Nongeneric?
            return TResponse.Error(ex);
        }
    }
}
```

Without using Reflection, in the catch block won't be possible to create the proper `Result` to return.

Below is an example of doing that with Reflection
```csharp
public sealed class ExceptionPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
    where TRequest : IRequest<TResponse>
    where TResponse : IResult
{
    private readonly MethodInfo? _operationResultError;
    private readonly Type _type = typeof(TResponse);
    private readonly Type _typeOperationResult = typeof(Result);

    public ExceptionPipelineBehavior()
    {
        if (_type.IsGenericType)
        {
            _operationResultError = _typeOperationResult.GetMethod(nameof(Result.Error), 1, new[] { typeof(Exception) })!;
            _operationResultError = _operationResultError.MakeGenericMethod(_type.GetGenericArguments());
        }
    }

    public async Task<TResponse> Handle(TRequest request, Func<TRequest, Task<TResponse>> next)
    {
        try
        {
            var response = await next(request);

            return response;
        }
        catch (Exception e)
        {
            return _type == _typeOperationResult
                ? (TResponse)Convert.ChangeType(Result.Error(e), _type)
                : (TResponse)Convert.ChangeType(_operationResultError!.Invoke(null, new object[] { e })!, _type)!;
        }
    }
}
```

# The new capability

Using the [static abstract members in interfaces](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/static-abstracts-in-interfaces) feature from C# it is possible.

And now we can remove the reflection stuff and make it simple like that:

```csharp
public sealed class ExceptionPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
    where TRequest : IRequest<TResponse>
    where TResponse : IResult<TResponse>
{
    public async Task<TResponse> Handle(TRequest request, Func<TRequest, Task<TResponse>> next)
    {
        try
        {
            return await next(request);
        }
        catch (Exception ex)
        {
            return TResponse.Error(ex);
        }
    }
}
```


# Dropped support to netstandard2.0 and net5.0

Since OperationResult is stable in version 3.1, I don't see any downsides to creating a new major version with that breaking change.

